### PR TITLE
Add tf2_web_republisher to Gazebo launch files

### DIFF
--- a/blue_gazebo/launch/blue_pickup_world.launch
+++ b/blue_gazebo/launch/blue_pickup_world.launch
@@ -47,6 +47,9 @@
   </node>
 
   <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
+  <node name="tf2_web_republisher"
+    pkg="tf2_web_republisher"
+    type="tf2_web_republisher" />
 
   <node
     name="$(anon blue_controller_spawner)"

--- a/blue_gazebo/launch/blue_world.launch
+++ b/blue_gazebo/launch/blue_world.launch
@@ -47,5 +47,8 @@
   </node>
 
   <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
+  <node name="tf2_web_republisher"
+    pkg="tf2_web_republisher"
+    type="tf2_web_republisher" />
 
 </launch>


### PR DESCRIPTION
Python API needs it :)

I think we should also rethink the way these launch files are structured sometime in the next week or so?